### PR TITLE
Various updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "HXUI/gdifonts"]
+	path = HXUI/gdifonts
+	url = git@github.com:ThornyFFXI/gdifonts.git

--- a/HXUI/HXUI.lua
+++ b/HXUI/HXUI.lua
@@ -152,6 +152,10 @@ T{
 
 	inventoryTrackerScale = 1,
 	inventoryTrackerFontOffset = 0,
+    inventoryTrackerOpacity = 1.0,
+    inventoryTrackerColumnCount = 5,
+    inventoryTrackerRowCount = 6,
+    inventoryShowCount = true,
 
 	partyListScaleX = 1,
 	partyListScaleY = 1,
@@ -698,6 +702,10 @@ local function UpdateUserSettings()
 	gAdjustedSettings.inventoryTrackerSettings.dotSpacing = ns.inventoryTrackerSettings.dotSpacing * us.inventoryTrackerScale;
 	gAdjustedSettings.inventoryTrackerSettings.groupSpacing = ns.inventoryTrackerSettings.groupSpacing * us.inventoryTrackerScale;
 	gAdjustedSettings.inventoryTrackerSettings.font_settings.font_height = math.max(ns.inventoryTrackerSettings.font_settings.font_height + us.inventoryTrackerFontOffset, 1);
+    gAdjustedSettings.inventoryTrackerSettings.columnCount = us.inventoryTrackerColumnCount;
+    gAdjustedSettings.inventoryTrackerSettings.rowCount = us.inventoryTrackerRowCount;
+    gAdjustedSettings.inventoryTrackerSettings.opacity = us.inventoryTrackerOpacity;
+    gAdjustedSettings.inventoryTrackerSettings.showText = us.inventoryShowCount;
 
 	-- Enemy List
 	gAdjustedSettings.enemyListSettings.barWidth = ns.enemyListSettings.barWidth * us.enemyListScaleX;

--- a/HXUI/HXUI.lua
+++ b/HXUI/HXUI.lua
@@ -106,6 +106,7 @@ T{
 	noBookendRounding = 4,
 	lockPositions = false,
     tooltipScale = 1.0,
+    hideDuringEvents = true,
 
 	showPlayerBar = true,
 	showTargetBar = true,
@@ -127,6 +128,7 @@ T{
 	playerBarFontOffset = 0,
 	showPlayerBarBookends = true,
 	alwaysShowMpBar = true,
+    playerBarHideDuringEvents = true,
 
 	targetBarScaleX = 1,
 	targetBarScaleY = 1,
@@ -135,6 +137,7 @@ T{
 	showTargetBarBookends = true,
 	showEnemyId = false;
 	alwaysShowHealthPercent = false,
+    targetBarHideDuringEvents = true,
 
 	enemyListScaleX = 1,
 	enemyListScaleY = 1,
@@ -170,6 +173,7 @@ T{
 	partyListCursor = 'GreyArrow.png',
 	partyListBackground = 'BlueGradient.png',
 	partyListEntrySpacing = 0,
+    partyListHideDuringEvents = true,
 
 	castBarScaleX = 1,
 	castBarScaleY = 1,
@@ -800,9 +804,9 @@ end
 
 function GetHidden()
 
-	if (GetEventSystemActive()) then
-		return true;
-	end
+	if (gConfig.hideDuringEvents and GetEventSystemActive()) then
+    	return true;
+    end
 
 	if (string.match(GetMenuName(), 'map')) then
 		return true;
@@ -824,12 +828,17 @@ end
 * desc : Event called when the Direct3D device is presenting a scene.
 --]]
 ashita.events.register('d3d_present', 'present_cb', function ()
+    local eventSystemActive = GetEventSystemActive();
 
 	if (GetHidden() == false) then
-		if (gConfig.showPlayerBar) then
+		if (not gConfig.showPlayerBar or (gConfig.playerBarHideDuringEvents and eventSystemActive)) then
+            playerBar.SetHidden(true);
+        else
 			playerBar.DrawWindow(gAdjustedSettings.playerBarSettings);
 		end
-		if (gConfig.showTargetBar) then
+        if (not gConfig.showTargetBar or (gConfig.targetBarHideDuringEvents and eventSystemActive)) then
+            targetBar.SetHidden(true);
+        else
 			targetBar.DrawWindow(gAdjustedSettings.targetBarSettings);
 		end
 		if (gConfig.showEnemyList) then
@@ -844,7 +853,9 @@ ashita.events.register('d3d_present', 'present_cb', function ()
 		if (gConfig.showInventoryTracker) then
 			inventoryTracker.DrawWindow(gAdjustedSettings.inventoryTrackerSettings);
 		end
-		if (gConfig.showPartyList) then
+        if (not gConfig.showPartyList or (gConfig.partyListHideDuringEvents and eventSystemActive)) then
+            partyList.SetHidden(true);
+        else
 			partyList.DrawWindow(gAdjustedSettings.partyListSettings);
 		end
 		if (gConfig.showCastBar) then

--- a/HXUI/HXUI.lua
+++ b/HXUI/HXUI.lua
@@ -42,6 +42,7 @@ local configMenu = require('configmenu');
 local debuffHandler = require('debuffhandler');
 local patchNotes = require('patchNotes');
 local statusHandler = require('statushandler');
+local gdi = require('gdifonts.include');
 
 -- =================
 -- = HXUI DEV ONLY =
@@ -561,42 +562,28 @@ T{
 	T{
 		barWidth = 500,
 		barHeight = 20,
-		spellOffsetY = 0,
+		spellOffsetY = 2,
 		percentOffsetY = 2,
 		percentOffsetX = -10,
-		spell_font_settings = 
+		spell_font_settings =
 		T{
-			visible = true,
-			locked = true,
+            font_alignment = gdi.Alignment.Left,
 			font_family = 'Consolas',
-			font_height = 11,
-			color = 0xFFFFFFFF,
-			bold = false,
-			italic = true;
-			color_outline = 0xFF000000,
-			draw_flags = 0x10,
-			background = 
-			T{
-				visible = false,
-			},
-			right_justified = false;
+			font_height = 20,
+			font_color = 0xFFFFFFFF,
+			font_flags = gdi.FontFlags.Bold,
+			outline_color = 0xFF000000,
+            outline_width = 2,
 		};
-		percent_font_settings = 
+		percent_font_settings =
 		T{
-			visible = true,
-			locked = true,
+            font_alignment = gdi.Alignment.Right,
 			font_family = 'Consolas',
-			font_height = 11,
-			color = 0xFFFFFFFF,
-			bold = false,
-			italic = true;
-			color_outline = 0xFF000000,
-			draw_flags = 0x10,
-			background = 
-			T{
-				visible = false,
-			},
-			right_justified = true;
+			font_height = 20,
+			font_color = 0xFFFFFFFF,
+			font_flags = gdi.FontFlags.Bold,
+			outline_color = 0xFF000000,
+            outline_width = 2,
 		};
 	};
 };
@@ -882,6 +869,10 @@ ashita.events.register('load', 'load_cb', function ()
 	inventoryTracker.Initialize(gAdjustedSettings.inventoryTrackerSettings);
 	partyList.Initialize(gAdjustedSettings.partyListSettings);
 	castBar.Initialize(gAdjustedSettings.castBarSettings);
+end);
+
+ashita.events.register('unload', 'unload_cb', function ()
+    gdi:destroy_interface()
 end);
 
 ashita.events.register('command', 'command_cb', function (e)

--- a/HXUI/HXUI.lua
+++ b/HXUI/HXUI.lua
@@ -105,7 +105,7 @@ T{
 
 	noBookendRounding = 4,
 	lockPositions = false,
-
+    tooltipScale = 1.0,
 
 	showPlayerBar = true,
 	showTargetBar = true,
@@ -569,9 +569,9 @@ T{
 		T{
             font_alignment = gdi.Alignment.Left,
 			font_family = 'Consolas',
-			font_height = 20,
+			font_height = 15,
 			font_color = 0xFFFFFFFF,
-			font_flags = gdi.FontFlags.Bold,
+			font_flags = gdi.FontFlags.Italic,
 			outline_color = 0xFF000000,
             outline_width = 2,
 		};
@@ -579,9 +579,9 @@ T{
 		T{
             font_alignment = gdi.Alignment.Right,
 			font_family = 'Consolas',
-			font_height = 20,
+			font_height = 15,
 			font_color = 0xFFFFFFFF,
-			font_flags = gdi.FontFlags.Bold,
+			font_flags = gdi.FontFlags.Italic,
 			outline_color = 0xFF000000,
             outline_width = 2,
 		};

--- a/HXUI/HXUI.lua
+++ b/HXUI/HXUI.lua
@@ -176,6 +176,7 @@ T{
     partyListHideDuringEvents = true,
     partyListExpandHeight = false,
     partyListAlignBottom = false,
+    partyListMinRows = 1,
 
 	castBarScaleX = 1,
 	castBarScaleY = 1,
@@ -484,6 +485,7 @@ T{
 		entrySpacing = 8,
         expandHeight = false,
         alignBottom = false,
+        minRows = 1,
 
 		hp_font_settings = 
 		T{
@@ -691,6 +693,7 @@ local function UpdateUserSettings()
 	gAdjustedSettings.partyListSettings.entrySpacing = ns.partyListSettings.entrySpacing + us.partyListEntrySpacing;
     gAdjustedSettings.partyListSettings.expandHeight = us.partyListExpandHeight;
     gAdjustedSettings.partyListSettings.alignBottom = us.partyListAlignBottom;
+    gAdjustedSettings.partyListSettings.minRows = us.partyListMinRows;
 
 	-- Player Bar
 	gAdjustedSettings.playerBarSettings.barWidth = ns.playerBarSettings.barWidth * us.playerBarScaleX;

--- a/HXUI/HXUI.lua
+++ b/HXUI/HXUI.lua
@@ -174,6 +174,8 @@ T{
 	partyListBackground = 'BlueGradient.png',
 	partyListEntrySpacing = 0,
     partyListHideDuringEvents = true,
+    partyListExpandHeight = false,
+    partyListAlignBottom = false,
 
 	castBarScaleX = 1,
 	castBarScaleY = 1,
@@ -480,6 +482,8 @@ T{
 		buffOffset = 10,
 		xivBuffOffsetY = 1,
 		entrySpacing = 8,
+        expandHeight = false,
+        alignBottom = false,
 
 		hp_font_settings = 
 		T{
@@ -685,6 +689,8 @@ local function UpdateUserSettings()
     gAdjustedSettings.partyListSettings.name_font_settings.font_height = math.max(ns.partyListSettings.name_font_settings.font_height + us.partyListFontOffset, 1);
 	gAdjustedSettings.partyListSettings.iconSize = ns.partyListSettings.iconSize * us.partyListBuffScale;
 	gAdjustedSettings.partyListSettings.entrySpacing = ns.partyListSettings.entrySpacing + us.partyListEntrySpacing;
+    gAdjustedSettings.partyListSettings.expandHeight = us.partyListExpandHeight;
+    gAdjustedSettings.partyListSettings.alignBottom = us.partyListAlignBottom;
 
 	-- Player Bar
 	gAdjustedSettings.playerBarSettings.barWidth = ns.playerBarSettings.barWidth * us.playerBarScaleX;

--- a/HXUI/HXUI.lua
+++ b/HXUI/HXUI.lua
@@ -149,6 +149,8 @@ T{
 
 	gilTrackerScale = 1,
 	gilTrackerFontOffset = 0,
+    gilTrackerPosOffset = { 0, -7 },
+    gilTrackerRightAlign = true,
 
 	inventoryTrackerScale = 1,
 	inventoryTrackerFontOffset = 0,
@@ -696,6 +698,13 @@ local function UpdateUserSettings()
 	-- Gil Tracker
 	gAdjustedSettings.gilTrackerSettings.iconScale = ns.gilTrackerSettings.iconScale * us.gilTrackerScale;
 	gAdjustedSettings.gilTrackerSettings.font_settings.font_height = math.max(ns.gilTrackerSettings.font_settings.font_height + us.gilTrackerFontOffset, 1);
+    gAdjustedSettings.gilTrackerSettings.font_settings.right_justified = us.gilTrackerRightAlign;
+    if (us.gilTrackerRightAlign) then
+        gAdjustedSettings.gilTrackerSettings.offsetX = ns.gilTrackerSettings.offsetX + us.gilTrackerPosOffset[1];
+    else
+        gAdjustedSettings.gilTrackerSettings.offsetX = (ns.gilTrackerSettings.offsetX + us.gilTrackerPosOffset[1]) * -1;
+    end
+    gAdjustedSettings.gilTrackerSettings.offsetY = us.gilTrackerPosOffset[2];
 	
 	-- Inventory Tracker
 	gAdjustedSettings.inventoryTrackerSettings.dotRadius = ns.inventoryTrackerSettings.dotRadius * us.inventoryTrackerScale;

--- a/HXUI/castbar.lua
+++ b/HXUI/castbar.lua
@@ -2,13 +2,15 @@ require('common');
 local imgui = require('imgui');
 local fonts = require('fonts');
 local progressbar = require('progressbar');
+local gdi = require('gdifonts.include');
+local encoding = require('gdifonts.encoding');
 
 local spellText;
 local percentText;
 
 local function UpdateTextVisibility(visible)
-	spellText:SetVisible(visible);
-	percentText:SetVisible(visible);
+	spellText:set_visible(visible);
+	percentText:set_visible(visible);
 end
 
 local castbar = {
@@ -27,9 +29,9 @@ end
 
 castbar.GetLabelText = function()
 	if (castbar.currentSpellId) then
-		return castbar.GetSpellName(castbar.currentSpellId);
+		return encoding:ShiftJIS_To_UTF8(castbar.GetSpellName(castbar.currentSpellId), true);
 	elseif (castbar.currentItemId) then
-		return castbar.GetItemName(castbar.currentItemId)
+		return encoding:ShiftJIS_To_UTF8(castbar.GetItemName(castbar.currentItemId), true);
 	else
 		return '';
 	end
@@ -62,13 +64,13 @@ castbar.DrawWindow = function(settings)
 			-- Draw Spell/Item name
 			imgui.SameLine();
 
-			spellText:SetPositionX(startX);
-			spellText:SetPositionY(startY + settings.barHeight + settings.spellOffsetY);
-			spellText:SetText(showConfig[1] and 'Configuration Mode' or castbar.GetLabelText());
+			spellText:set_position_x(startX);
+			spellText:set_position_y(startY + settings.barHeight + settings.spellOffsetY);
+			spellText:set_text(showConfig[1] and 'Configuration Mode' or castbar.GetLabelText());
 
-			percentText:SetPositionX(startX + settings.barWidth - imgui.GetStyle().FramePadding.x * 4);
-			percentText:SetPositionY(startY + settings.barHeight + settings.percentOffsetY);
-			percentText:SetText(showConfig[1] and '50%' or math.floor(percent * 100) .. '%');
+			percentText:set_position_x(startX + settings.barWidth - imgui.GetStyle().FramePadding.x * 4);
+			percentText:set_position_y(startY + settings.barHeight + settings.percentOffsetY);
+			percentText:set_text(showConfig[1] and '50%' or math.floor(percent * 100) .. '%');
 
 			UpdateTextVisibility(true);
 		end
@@ -82,8 +84,8 @@ castbar.DrawWindow = function(settings)
 end
 
 castbar.UpdateFonts = function(settings)
-	spellText:SetFontHeight(settings.spell_font_settings.font_height);
-	percentText:SetFontHeight(settings.percent_font_settings.font_height);
+	spellText:set_font_height(settings.spell_font_settings.font_height);
+	percentText:set_font_height(settings.percent_font_settings.font_height);
 end
 
 castbar.SetHidden = function(hidden)
@@ -93,8 +95,8 @@ castbar.SetHidden = function(hidden)
 end
 
 castbar.Initialize = function(settings)
-	spellText = fonts.new(settings.spell_font_settings);
-	percentText = fonts.new(settings.percent_font_settings);
+	spellText = gdi:create_object(settings.spell_font_settings);
+	percentText = gdi:create_object(settings.percent_font_settings);
 end
 
 castbar.HandleActionPacket = function(actionPacket)

--- a/HXUI/configmenu.lua
+++ b/HXUI/configmenu.lua
@@ -354,6 +354,16 @@ config.DrawWindow = function(us)
                 gConfig.gilTrackerFontOffset = fontOffset[1];
                 UpdateSettings();
             end
+            if (imgui.Checkbox('Right Align', { gConfig.gilTrackerRightAlign })) then
+                gConfig.gilTrackerRightAlign = not gConfig.gilTrackerRightAlign;
+                UpdateSettings();
+            end
+            local posOffset = { gConfig.gilTrackerPosOffset[1], gConfig.gilTrackerPosOffset[2] };
+            if (imgui.InputInt2('Position Offset', posOffset)) then
+                gConfig.gilTrackerPosOffset[1] = posOffset[1];
+                gConfig.gilTrackerPosOffset[2] = posOffset[2];
+                UpdateSettings();
+            end
             imgui.EndChild();
         end
         if (imgui.CollapsingHeader("Inventory Tracker")) then

--- a/HXUI/configmenu.lua
+++ b/HXUI/configmenu.lua
@@ -357,9 +357,28 @@ config.DrawWindow = function(us)
             imgui.EndChild();
         end
         if (imgui.CollapsingHeader("Inventory Tracker")) then
-            imgui.BeginChild("InventoryTrackerSettings", { 0, 160 }, true);
+            imgui.BeginChild("InventoryTrackerSettings", { 0, 210 }, true);
             if (imgui.Checkbox('Enabled', { gConfig.showInventoryTracker })) then
                 gConfig.showInventoryTracker = not gConfig.showInventoryTracker;
+                UpdateSettings();
+            end
+            if (imgui.Checkbox('Show Count', { gConfig.inventoryShowCount })) then
+                gConfig.inventoryShowCount = not gConfig.inventoryShowCount;
+                UpdateSettings();
+            end
+            local columnCount = { gConfig.inventoryTrackerColumnCount };
+            if (imgui.SliderInt('Columns', columnCount, 1, 80)) then
+                gConfig.inventoryTrackerColumnCount = columnCount[1];
+                UpdateSettings();
+            end
+            local rowCount = { gConfig.inventoryTrackerRowCount };
+            if (imgui.SliderInt('Rows', rowCount, 1, 80)) then
+                gConfig.inventoryTrackerRowCount = rowCount[1];
+                UpdateSettings();
+            end
+            local opacity = { gConfig.inventoryTrackerOpacity };
+            if (imgui.SliderFloat('Opacity', opacity, 0, 1.0, '%.2f')) then
+                gConfig.inventoryTrackerOpacity = opacity[1];
                 UpdateSettings();
             end
             local scale = { gConfig.inventoryTrackerScale };

--- a/HXUI/configmenu.lua
+++ b/HXUI/configmenu.lua
@@ -28,7 +28,7 @@ config.DrawWindow = function(us)
         end
         imgui.BeginChild("Config Options", { 0, 0 }, true);
         if (imgui.CollapsingHeader("General")) then
-            imgui.BeginChild("GeneralSettings", { 0, 180 }, true);
+            imgui.BeginChild("GeneralSettings", { 0, 210 }, true);
             if (imgui.Checkbox('Lock HUD Position', { gConfig.lockPositions })) then
                 gConfig.lockPositions = not gConfig.lockPositions;
                 UpdateSettings();
@@ -92,16 +92,25 @@ config.DrawWindow = function(us)
             end
             imgui.ShowHelp('Scales the size of the tooltip. Note that text may appear blured if scaled too large.');
 
+            if (imgui.Checkbox('Hide During Events', { gConfig.hideDuringEvents })) then
+                gConfig.hideDuringEvents = not gConfig.hideDuringEvents;
+                UpdateSettings();
+            end
+
             imgui.EndChild();
         end
         if (imgui.CollapsingHeader("Player Bar")) then
-            imgui.BeginChild("PlayerBarSettings", { 0, 160 }, true);
+            imgui.BeginChild("PlayerBarSettings", { 0, 210 }, true);
             if (imgui.Checkbox('Enabled', { gConfig.showPlayerBar })) then
                 gConfig.showPlayerBar = not gConfig.showPlayerBar;
                 UpdateSettings();
             end
             if (imgui.Checkbox('Show Bookends', { gConfig.showPlayerBarBookends })) then
                 gConfig.showPlayerBarBookends = not gConfig.showPlayerBarBookends;
+                UpdateSettings();
+            end
+            if (imgui.Checkbox('Hide During Events', { gConfig.playerBarHideDuringEvents })) then
+                gConfig.playerBarHideDuringEvents = not gConfig.playerBarHideDuringEvents;
                 UpdateSettings();
             end
             if (imgui.Checkbox('Always Show MP Bar', { gConfig.alwaysShowMpBar })) then
@@ -127,13 +136,17 @@ config.DrawWindow = function(us)
             imgui.EndChild();
         end
         if (imgui.CollapsingHeader("Target Bar")) then
-            imgui.BeginChild("TargetBarSettings", { 0, 220 }, true);
+            imgui.BeginChild("TargetBarSettings", { 0, 270 }, true);
             if (imgui.Checkbox('Enabled', { gConfig.showTargetBar })) then
                 gConfig.showTargetBar = not gConfig.showTargetBar;
                 UpdateSettings();
             end
             if (imgui.Checkbox('Show Bookends', { gConfig.showTargetBarBookends })) then
                 gConfig.showTargetBarBookends = not gConfig.showTargetBarBookends;
+                UpdateSettings();
+            end
+            if (imgui.Checkbox('Hide During Events', { gConfig.targetBarHideDuringEvents })) then
+                gConfig.targetBarHideDuringEvents = not gConfig.targetBarHideDuringEvents;
                 UpdateSettings();
             end
             if (imgui.Checkbox('Show Enemy Id', { gConfig.showEnemyId })) then
@@ -169,7 +182,7 @@ config.DrawWindow = function(us)
             imgui.EndChild();
         end
         if (imgui.CollapsingHeader("Enemy List")) then
-            imgui.BeginChild("EnemyListSettings", { 0, 160 }, true);
+            imgui.BeginChild("EnemyListSettings", { 0, 180 }, true);
             if (imgui.Checkbox('Enabled', { gConfig.showEnemyList })) then
                 gConfig.showEnemyList = not gConfig.showEnemyList;
                 UpdateSettings();
@@ -201,7 +214,7 @@ config.DrawWindow = function(us)
             imgui.EndChild();
         end
         if (imgui.CollapsingHeader("Party List")) then
-            imgui.BeginChild("PartyListSettings", { 0, 300 }, true);
+            imgui.BeginChild("PartyListSettings", { 0, 380 }, true);
             if (imgui.Checkbox('Enabled', { gConfig.showPartyList })) then
                 gConfig.showPartyList = not gConfig.showPartyList;
                 UpdateSettings();
@@ -212,6 +225,10 @@ config.DrawWindow = function(us)
             end
             if (imgui.Checkbox('Show When Solo', { gConfig.showPartyListWhenSolo })) then
                 gConfig.showPartyListWhenSolo = not gConfig.showPartyListWhenSolo;
+                UpdateSettings();
+            end
+            if (imgui.Checkbox('Hide During Events', { gConfig.partyListHideDuringEvents })) then
+                gConfig.partyListHideDuringEvents = not gConfig.partyListHideDuringEvents;
                 UpdateSettings();
             end
             local scaleX = { gConfig.partyListScaleX };

--- a/HXUI/configmenu.lua
+++ b/HXUI/configmenu.lua
@@ -28,7 +28,7 @@ config.DrawWindow = function(us)
         end
         imgui.BeginChild("Config Options", { 0, 0 }, true);
         if (imgui.CollapsingHeader("General")) then
-            imgui.BeginChild("GeneralSettings", { 0, 150 }, true);
+            imgui.BeginChild("GeneralSettings", { 0, 180 }, true);
             if (imgui.Checkbox('Lock HUD Position', { gConfig.lockPositions })) then
                 gConfig.lockPositions = not gConfig.lockPositions;
                 UpdateSettings();
@@ -84,6 +84,13 @@ config.DrawWindow = function(us)
                 UpdateSettings();
             end
             imgui.ShowHelp('For bars with no bookends, how round they should be.');
+
+            local tooltipScale = { gConfig.tooltipScale };
+            if (imgui.SliderFloat('Tooltip Scale', tooltipScale, 0.1, 3.0, '%.2f')) then
+                gConfig.tooltipScale = tooltipScale[1];
+                UpdateSettings();
+            end
+            imgui.ShowHelp('Scales the size of the tooltip. Note that text may appear blured if scaled too large.');
 
             imgui.EndChild();
         end

--- a/HXUI/configmenu.lua
+++ b/HXUI/configmenu.lua
@@ -158,7 +158,7 @@ config.DrawWindow = function(us)
                 gConfig.alwaysShowHealthPercent = not gConfig.alwaysShowHealthPercent;
                 UpdateSettings();
             end
-            imgui.ShowHelp('Always display the percent of HP remanining regardless if the target is an enemy or not.'); 
+            imgui.ShowHelp('Always display the percent of HP remanining regardless if the target is an enemy or not.');
             local scaleX = { gConfig.targetBarScaleX };
             if (imgui.SliderFloat('Scale X', scaleX, 0.1, 3.0, '%.1f')) then
                 gConfig.targetBarScaleX = scaleX[1];
@@ -237,6 +237,11 @@ config.DrawWindow = function(us)
             end
             if (imgui.Checkbox('Expand Height', { gConfig.partyListExpandHeight })) then
                 gConfig.partyListExpandHeight = not gConfig.partyListExpandHeight;
+                UpdateSettings();
+            end
+            local minRows = { gConfig.partyListMinRows };
+            if (imgui.SliderInt('Min Rows', minRows, 1, 6)) then
+                gConfig.partyListMinRows = minRows[1];
                 UpdateSettings();
             end
             local scaleX = { gConfig.partyListScaleX };

--- a/HXUI/configmenu.lua
+++ b/HXUI/configmenu.lua
@@ -214,7 +214,7 @@ config.DrawWindow = function(us)
             imgui.EndChild();
         end
         if (imgui.CollapsingHeader("Party List")) then
-            imgui.BeginChild("PartyListSettings", { 0, 380 }, true);
+            imgui.BeginChild("PartyListSettings", { 0, 440 }, true);
             if (imgui.Checkbox('Enabled', { gConfig.showPartyList })) then
                 gConfig.showPartyList = not gConfig.showPartyList;
                 UpdateSettings();
@@ -229,6 +229,14 @@ config.DrawWindow = function(us)
             end
             if (imgui.Checkbox('Hide During Events', { gConfig.partyListHideDuringEvents })) then
                 gConfig.partyListHideDuringEvents = not gConfig.partyListHideDuringEvents;
+                UpdateSettings();
+            end
+            if (imgui.Checkbox('Align Bottom', { gConfig.partyListAlignBottom })) then
+                gConfig.partyListAlignBottom = not gConfig.partyListAlignBottom;
+                UpdateSettings();
+            end
+            if (imgui.Checkbox('Expand Height', { gConfig.partyListExpandHeight })) then
+                gConfig.partyListExpandHeight = not gConfig.partyListExpandHeight;
                 UpdateSettings();
             end
             local scaleX = { gConfig.partyListScaleX };

--- a/HXUI/giltracker.lua
+++ b/HXUI/giltracker.lua
@@ -19,8 +19,9 @@ end
 giltracker.DrawWindow = function(settings)
     -- Obtain the player entity..
     local player = AshitaCore:GetMemoryManager():GetPlayer();
+    local playerEnt = GetPlayerEntity();
 
-	if (player == nil) then
+	if (player == nil or playerEnt == nil) then
 		UpdateTextVisibility(false);
 		return;
 	end
@@ -53,14 +54,14 @@ giltracker.DrawWindow = function(settings)
 		imgui.Image(tonumber(ffi.cast("uint32_t", gilTexture.image)), { settings.iconScale, settings.iconScale });
 
 		gilText:SetText(FormatInt(gilAmount.Count));
-		gilText:SetPositionX(cursorX + settings.offsetX);
+        local posOffsetX = settings.font_settings.right_justified and settings.offsetX or settings.offsetX + settings.iconScale;
+		gilText:SetPositionX(cursorX + posOffsetX);
 		gilText:SetPositionY(cursorY + (settings.iconScale/2) + settings.offsetY);
 
-		UpdateTextVisibility(true);	
+		UpdateTextVisibility(true);
     end
 	imgui.End();
 end
-
 
 giltracker.Initialize = function(settings)
     gilText = fonts.new(settings.font_settings);
@@ -69,6 +70,7 @@ end
 
 giltracker.UpdateFonts = function(settings)
     gilText:SetFontHeight(settings.font_settings.font_height);
+    gilText:SetRightJustified(settings.font_settings.right_justified);
 end
 
 giltracker.SetHidden = function(hidden)

--- a/HXUI/inventorytracker.lua
+++ b/HXUI/inventorytracker.lua
@@ -81,18 +81,21 @@ inventoryTracker.DrawWindow = function(settings)
 			x = x + ((groupNum - 1) * groupOffsetX);
 
 			if (i > usedBagSlots) then
-				draw_circle({x + locX + imgui.GetStyle().FramePadding.x, y + locY}, settings.dotRadius, {0, .07, .17, 1}, settings.dotRadius * 3, true)
+				draw_circle({x + locX + imgui.GetStyle().FramePadding.x, y + locY}, settings.dotRadius, {0, .07, .17, settings.opacity}, settings.dotRadius * 3, true)
 			else
-				draw_circle({x + locX + imgui.GetStyle().FramePadding.x, y + locY}, settings.dotRadius, {.37, .7, .88, 1}, settings.dotRadius * 3, true)
-				draw_circle({x + locX + imgui.GetStyle().FramePadding.x, y + locY}, settings.dotRadius, {0, .07, .17, 1}, settings.dotRadius * 3, false)
+				draw_circle({x + locX + imgui.GetStyle().FramePadding.x, y + locY}, settings.dotRadius, {.37, .7, .88, settings.opacity}, settings.dotRadius * 3, true)
+				draw_circle({x + locX + imgui.GetStyle().FramePadding.x, y + locY}, settings.dotRadius, {0, .07, .17, settings.opacity}, settings.dotRadius * 3, false)
 			end
 		end
 
-		inventoryText:SetText(usedBagSlots.. '/'..maxBagSlots);
-		inventoryText:SetPositionX(locX + winSizeX);
-		inventoryText:SetPositionY(locY + settings.textOffsetY - inventoryText:GetFontHeight());
-
-		UpdateTextVisibility(true);	
+        if (settings.showText) then
+            inventoryText:SetText(usedBagSlots.. '/'..maxBagSlots);
+            inventoryText:SetPositionX(locX + winSizeX);
+		    inventoryText:SetPositionY(locY + settings.textOffsetY - inventoryText:GetFontHeight());
+            UpdateTextVisibility(true);
+        else
+            UpdateTextVisibility(false);
+        end
     end
 	imgui.End();
 end

--- a/HXUI/partylist.lua
+++ b/HXUI/partylist.lua
@@ -109,31 +109,26 @@ local function DrawMember(memIdx, settings)
 
     local memInfo = GetMemberInformation(memIdx);
     if (memInfo == nil) then
-        if (settings.expandHeight) then
-            -- dummy data to render an empty space
-            memInfo = {};
-            memInfo.hp = 0;
-            memInfo.hpp = 0;
-            memInfo.maxhp = 0;
-            memInfo.mp = 0;
-            memInfo.mpp = 0;
-            memInfo.maxmp = 0;
-            memInfo.tp = 0;
-            memInfo.job = '';
-            memInfo.level = '';
-            memInfo.targeted = false;
-            memInfo.serverid = 0;
-            memInfo.buffs = nil;
-            memInfo.sync = false;
-            memInfo.subTargeted = false;
-            memInfo.zone = '';
-            memInfo.inzone = false;
-            memInfo.name = '';
-            memInfo.leader = false;
-        else
-            UpdateTextVisibilityByMember(memIdx, false);
-            return;
-        end
+        -- dummy data to render an empty space
+        memInfo = {};
+        memInfo.hp = 0;
+        memInfo.hpp = 0;
+        memInfo.maxhp = 0;
+        memInfo.mp = 0;
+        memInfo.mpp = 0;
+        memInfo.maxmp = 0;
+        memInfo.tp = 0;
+        memInfo.job = '';
+        memInfo.level = '';
+        memInfo.targeted = false;
+        memInfo.serverid = 0;
+        memInfo.buffs = nil;
+        memInfo.sync = false;
+        memInfo.subTargeted = false;
+        memInfo.zone = '';
+        memInfo.inzone = false;
+        memInfo.name = '';
+        memInfo.leader = false;
     end
 
     local subTargetActive = GetSubTargetActive();
@@ -371,7 +366,15 @@ partyList.DrawWindow = function(settings)
 		return;
 	end
 	local currJob = player:GetMainJob();
-    if (player.isZoning or currJob == 0 or (not gConfig.showPartyListWhenSolo and party:GetMemberIsActive(1) == 0)) then
+    local partyMemberCount = 1;
+    for i = 1, 5 do
+        if (party:GetMemberIsActive(i) ~= 0) then
+            partyMemberCount = partyMemberCount + 1
+        else
+            break
+        end
+    end
+    if (player.isZoning or currJob == 0 or (not gConfig.showPartyListWhenSolo and partyMemberCount == 1)) then
 		UpdateTextVisibility(false);
         return;
 	end
@@ -402,8 +405,11 @@ partyList.DrawWindow = function(settings)
         partySubTargeted = false;
         UpdateTextVisibility(true);
         for i = 0, 5 do
-            -- Remove all padding and draw each member
-            DrawMember(i, settings);
+            if (settings.expandHeight or i < partyMemberCount or i < settings.minRows) then
+                DrawMember(i, settings);
+            else
+                UpdateTextVisibilityByMember(i, false);
+            end
         end
         if (partyTargeted == false) then
             selectionPrim.visible = false;

--- a/HXUI/statushandler.lua
+++ b/HXUI/statushandler.lua
@@ -6,6 +6,7 @@
 local d3d8 = require('d3d8');
 local ffi = require('ffi');
 local imgui = require('imgui');
+local encoding = require('gdifonts.encoding');
 -------------------------------------------------------------------------------
 -- local state
 -------------------------------------------------------------------------------
@@ -179,10 +180,12 @@ statusHandler.render_tooltip = function(status)
     local name = resMan:GetString('buffs.names', status);
     if (name ~= nil and info ~= nil) then
         imgui.BeginTooltip();
-            imgui.Text(('%s (#%d)'):fmt(name, status));
+            imgui.SetWindowFontScale(gConfig.tooltipScale);
+            imgui.Text(('%s (#%d)'):fmt(encoding:ShiftJIS_To_UTF8(name, true), status));
             if (info.Description[1] ~= nil) then
-                imgui.Text(info.Description[1]);
+                imgui.Text(encoding:ShiftJIS_To_UTF8(info.Description[1], true));
             end
+            imgui.SetWindowFontScale(1);
         imgui.EndTooltip();
     end
 end


### PR DESCRIPTION
* Fixed rendering of Japanese text in Castbar and Status Icon tooltips.
* Added config for Inventory rows, columns, opacity and show count text.
* Added Tooltip scale config.
* Added giltracker options: Position Offset, Right Align (to have text appear on the right hand side left aligned).
* Added option to hide during events for: global, player bar, target bar, party list. Gives more control over what elements are hidden during an event.
* Added partylist options: Expand Height, Align Bottom, Min Rows.